### PR TITLE
Fixed testExtract

### DIFF
--- a/src/publicTest/java/PublicTests.java
+++ b/src/publicTest/java/PublicTests.java
@@ -48,7 +48,7 @@ public class PublicTests {
         assertIterableEquals(List.of(2, 3), () ->
             new ListOfArraysIteratorWrapper<>(extract));
 
-        assertIterableEquals(List.of(1, 2, 5), () ->
+        assertIterableEquals(List.of(1, 4, 5), () ->
             new ListOfArraysIteratorWrapper<>(list));
     }
 }


### PR DESCRIPTION
if we remove element 2 and 3 from the list {1, 2, 3, 4, 5} the remaining list must be {1, 4, 5}